### PR TITLE
Refactor RandomChordPractice component for better maintainability

### DIFF
--- a/app/exercises/random-chord-practice/components/back-navigation.tsx
+++ b/app/exercises/random-chord-practice/components/back-navigation.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { buttonVariants } from '@/components/ui/button'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { memo } from 'react'
+
+const BackNavigation = memo(function BackNavigation() {
+  return (
+    <div>
+      <Link
+        className={cn(buttonVariants({ variant: 'ghost' }), 'pl-2 pr-4')}
+        href="/exercises"
+      >
+        <ChevronLeft className="h-6 w-6" />
+        Back to Exercises
+      </Link>
+    </div>
+  )
+})
+
+export default BackNavigation

--- a/app/exercises/random-chord-practice/components/chord-display.tsx
+++ b/app/exercises/random-chord-practice/components/chord-display.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Chord } from '@/types/chord'
+import { ChordTypeAbbreviations } from '@/types/chord'
+import { Skeleton } from '@/components/ui/skeleton'
+import { memo } from 'react'
+
+interface ChordDisplayProps {
+  currentChord: Chord | null
+  nextChord: Chord | null
+  onTogglePlay: () => void
+}
+
+const ChordDisplay = memo(function ChordDisplay({
+  currentChord,
+  nextChord,
+  onTogglePlay,
+}: ChordDisplayProps) {
+  return (
+    <div className="flex flex-col items-center" onClick={onTogglePlay}>
+      {currentChord ? (
+        <div className="mb-4 text-7xl font-semibold tracking-tight sm:mb-8 sm:text-9xl">
+          {currentChord.root + ChordTypeAbbreviations[currentChord.type]}
+        </div>
+      ) : (
+        <Skeleton className="mb-4 h-24 w-48 sm:mb-8" />
+      )}
+      <div className="mb-4 text-2xl sm:text-3xl">Up Next...</div>
+      {nextChord ? (
+        <div className="text-6xl font-semibold tracking-tight sm:mb-8 sm:text-8xl">
+          {nextChord.root + ChordTypeAbbreviations[nextChord.type]}
+        </div>
+      ) : (
+        <Skeleton className="h-16 w-32" />
+      )}
+    </div>
+  )
+})
+
+export default ChordDisplay

--- a/app/exercises/random-chord-practice/components/diatonic-mode-settings.tsx
+++ b/app/exercises/random-chord-practice/components/diatonic-mode-settings.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Separator } from '@/components/ui/separator'
+import { Slider } from '@/components/ui/slider'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { MusicKey, GENERAL_MUSIC_KEYS } from '@/types/key'
+import { ScaleType } from '@/types/scale'
+import { memo } from 'react'
+
+interface DiatonicModeSettingsProps {
+  tempo: number
+  setTempo: (tempo: number) => void
+  selectedKey: MusicKey
+  setSelectedKey: (key: MusicKey) => void
+  selectedScaleType: ScaleType
+  setSelectedScaleType: (scaleType: ScaleType) => void
+}
+
+const DiatonicModeSettings = memo(function DiatonicModeSettings({
+  tempo,
+  setTempo,
+  selectedKey,
+  setSelectedKey,
+  selectedScaleType,
+  setSelectedScaleType,
+}: DiatonicModeSettingsProps) {
+  return (
+    <>
+      <Separator orientation="horizontal" className="mb-4" />
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <div className="font-semibold">Tempo</div>
+          <div>{tempo} BPM</div>
+        </div>
+        <Slider
+          value={[tempo]}
+          onValueChange={([value]) => {
+            setTempo(value)
+          }}
+          max={200}
+          min={30}
+          step={1}
+        />
+      </div>
+      <Separator orientation="horizontal" className="my-4" />
+      <div>
+        <div className="mb-3 font-semibold">Key</div>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          className="grid grid-cols-4 sm:grid-cols-6"
+          value={selectedKey}
+          onValueChange={(value) => {
+            setSelectedKey(value as MusicKey)
+          }}
+        >
+          {GENERAL_MUSIC_KEYS.map((note) => (
+            <ToggleGroupItem
+              key={note}
+              value={note}
+              className="text-sm font-semibold"
+            >
+              {note}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+      <Separator orientation="horizontal" className="my-4" />
+      <div>
+        <div className="mb-3 font-semibold">Scale type</div>
+        <Tabs
+          value={selectedScaleType}
+          onValueChange={(value) => {
+            setSelectedScaleType(value as ScaleType)
+          }}
+        >
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="major">Major</TabsTrigger>
+            <TabsTrigger value="natural minor">Minor</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+    </>
+  )
+})
+
+export default DiatonicModeSettings

--- a/app/exercises/random-chord-practice/components/metronome-controls.tsx
+++ b/app/exercises/random-chord-practice/components/metronome-controls.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Circle, Pause, Play } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { memo } from 'react'
+
+interface MetronomeControlsProps {
+  isPlaying: boolean
+  beat: number
+  onTogglePlay: () => void
+}
+
+const MetronomeControls = memo(function MetronomeControls({
+  isPlaying,
+  beat,
+  onTogglePlay,
+}: MetronomeControlsProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex items-center justify-between gap-8 py-12 sm:mb-12 sm:gap-16">
+        {[0, 1, 2, 3].map((i) => (
+          <Circle
+            key={i}
+            className={cn(
+              'h-12 w-12 fill-secondary-foreground sm:h-16 sm:w-16',
+              {
+                'fill-primary-foreground': i === beat,
+              },
+            )}
+          />
+        ))}
+      </div>
+      <Button className="h-12 w-36" onClick={onTogglePlay}>
+        {isPlaying ? (
+          <div className="flex items-center gap-1">
+            <Pause className="h-6 w-6" />
+            <div className="text-lg">Pause</div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1">
+            <Play className="h-6 w-6" />
+            <div className="text-lg">Play</div>
+          </div>
+        )}
+      </Button>
+    </div>
+  )
+})
+
+export default MetronomeControls

--- a/app/exercises/random-chord-practice/components/random-mode-settings.tsx
+++ b/app/exercises/random-chord-practice/components/random-mode-settings.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { Separator } from '@/components/ui/separator'
+import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Check } from 'lucide-react'
+import { MusicKey, GENERAL_MUSIC_KEYS } from '@/types/key'
+import { ChordType, TRIAD_CHORDTYPES, SEVENTH_CHORDTYPES } from '@/types/chord'
+import { memo } from 'react'
+
+interface RandomModeSettingsProps {
+  tempo: number
+  setTempo: (tempo: number) => void
+  isMetronomeMuted: boolean
+  setIsMetronomeMuted: (muted: boolean) => void
+  selectedRoots: MusicKey[]
+  setSelectedRoots: (roots: MusicKey[]) => void
+  selectedChordTypes: ChordType[]
+  setSelectedChordTypes: (chordTypes: ChordType[]) => void
+}
+
+const RandomModeSettings = memo(function RandomModeSettings({
+  tempo,
+  setTempo,
+  isMetronomeMuted,
+  setIsMetronomeMuted,
+  selectedRoots,
+  setSelectedRoots,
+  selectedChordTypes,
+  setSelectedChordTypes,
+}: RandomModeSettingsProps) {
+  return (
+    <>
+      <Separator orientation="horizontal" className="mb-4" />
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <div className="font-semibold">Tempo</div>
+          <div>{tempo} BPM</div>
+        </div>
+        <Slider
+          value={[tempo]}
+          onValueChange={([value]) => {
+            setTempo(value)
+          }}
+          max={200}
+          min={30}
+          step={1}
+        />
+      </div>
+      <Separator orientation="horizontal" className="my-4" />
+      <div className="flex items-center justify-between">
+        <div className="font-semibold">Metronome Sound</div>
+        <Switch
+          checked={!isMetronomeMuted}
+          onCheckedChange={(check) => {
+            setIsMetronomeMuted(!check)
+          }}
+        />
+      </div>
+      <Separator orientation="horizontal" className="my-4" />
+      <div>
+        <div className="mb-3 font-semibold">Roots</div>
+        <ToggleGroup
+          type="multiple"
+          variant="outline"
+          className="grid grid-cols-4 sm:grid-cols-6"
+          value={selectedRoots}
+          onValueChange={(value) => {
+            if (value.length > 0) {
+              setSelectedRoots(value as MusicKey[])
+            }
+          }}
+        >
+          {GENERAL_MUSIC_KEYS.map((note) => (
+            <ToggleGroupItem
+              key={note}
+              value={note}
+              className="text-sm font-semibold"
+            >
+              {note}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+      <Separator orientation="horizontal" className="my-4" />
+      <div>
+        <div className="mb-3 font-semibold">Chords</div>
+        <div className="grid grid-cols-2 items-start gap-4">
+          <ToggleGroup
+            type="multiple"
+            variant="outline"
+            className="flex flex-col"
+            value={selectedChordTypes.filter((chord) =>
+              TRIAD_CHORDTYPES.includes(chord),
+            )}
+            onValueChange={(value) => {
+              setSelectedChordTypes(
+                (value as ChordType[]).concat(
+                  selectedChordTypes.filter(
+                    (chord) => !TRIAD_CHORDTYPES.includes(chord),
+                  ),
+                ),
+              )
+            }}
+          >
+            {TRIAD_CHORDTYPES.map((chord) => (
+              <ToggleGroupItem
+                key={chord}
+                value={chord}
+                className="relative w-full font-semibold"
+              >
+                <div className="flex">{chord}</div>
+                {selectedChordTypes.includes(chord) && (
+                  <Check className="absolute right-4 h-5 w-5" />
+                )}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <ToggleGroup
+            type="multiple"
+            variant="outline"
+            className="flex flex-col"
+            value={selectedChordTypes.filter((chord) =>
+              SEVENTH_CHORDTYPES.includes(chord),
+            )}
+            onValueChange={(value) => {
+              setSelectedChordTypes(
+                (value as ChordType[]).concat(
+                  selectedChordTypes.filter(
+                    (chord) => !SEVENTH_CHORDTYPES.includes(chord),
+                  ),
+                ),
+              )
+            }}
+          >
+            {SEVENTH_CHORDTYPES.map((chord) => (
+              <ToggleGroupItem
+                key={chord}
+                value={chord}
+                className="relative w-full font-semibold"
+              >
+                <div className="flex">{chord}</div>
+                {selectedChordTypes.includes(chord) && (
+                  <Check className="absolute right-4 h-5 w-5" />
+                )}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
+      </div>
+    </>
+  )
+})
+
+export default RandomModeSettings

--- a/app/exercises/random-chord-practice/hooks/use-chord-generation.ts
+++ b/app/exercises/random-chord-practice/hooks/use-chord-generation.ts
@@ -51,10 +51,10 @@ export function useChordGeneration(
       throw new Error('Scale and chord types do not match')
     }
 
-    const random_index = Math.floor(Math.random() * scale.notes.length)
+    const randomIndex = Math.floor(Math.random() * scale.notes.length)
     return {
-      root: scale.notes[random_index],
-      type: chordTypes[random_index],
+      root: scale.notes[randomIndex],
+      type: chordTypes[randomIndex],
     }
   }, [scaleInfo])
 

--- a/app/exercises/random-chord-practice/hooks/use-chord-generation.ts
+++ b/app/exercises/random-chord-practice/hooks/use-chord-generation.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { MusicKey } from '@/types/key'
+import {
+  ChordType,
+  MAJOR_DIATONIC_CHORDTYPE,
+  NATURAL_MINOR_DIATONIC_CHORDTYPE,
+} from '@/types/chord'
+import { ScaleType, MAJOR_SCALES, NATURAL_MINOR_SCALES } from '@/types/scale'
+import { getRandomElement } from '@/lib/utils'
+
+export function useChordGeneration(
+  practiceMode: 'random' | 'diatonic',
+  selectedRoots: MusicKey[],
+  selectedChordTypes: ChordType[],
+  selectedKey: MusicKey,
+  selectedScaleType: ScaleType,
+) {
+  const scaleInfo = useMemo(() => {
+    if (selectedScaleType === 'major') {
+      return {
+        scale: MAJOR_SCALES.find((s) => s.key === selectedKey),
+        chordTypes: MAJOR_DIATONIC_CHORDTYPE,
+      }
+    } else if (selectedScaleType === 'natural minor') {
+      return {
+        scale: NATURAL_MINOR_SCALES.find((s) => s.key === selectedKey),
+        chordTypes: NATURAL_MINOR_DIATONIC_CHORDTYPE,
+      }
+    }
+    return null
+  }, [selectedKey, selectedScaleType])
+
+  const getRandomChord = useCallback(
+    () => ({
+      root: getRandomElement(selectedRoots),
+      type: getRandomElement(selectedChordTypes),
+    }),
+    [selectedRoots, selectedChordTypes],
+  )
+
+  const getRandomDiatonicChord = useCallback(() => {
+    if (!scaleInfo || !scaleInfo.scale) {
+      throw new Error('Scale not found')
+    }
+
+    const { scale, chordTypes } = scaleInfo
+
+    if (scale.notes.length !== chordTypes.length) {
+      throw new Error('Scale and chord types do not match')
+    }
+
+    const random_index = Math.floor(Math.random() * scale.notes.length)
+    return {
+      root: scale.notes[random_index],
+      type: chordTypes[random_index],
+    }
+  }, [scaleInfo])
+
+  const generateChord = useCallback(() => {
+    if (practiceMode === 'random') {
+      return getRandomChord()
+    } else if (practiceMode === 'diatonic') {
+      return getRandomDiatonicChord()
+    } else {
+      throw new Error('Invalid practice mode')
+    }
+  }, [practiceMode, getRandomChord, getRandomDiatonicChord])
+
+  return {
+    generateChord,
+  }
+}

--- a/app/exercises/random-chord-practice/hooks/use-metronome.ts
+++ b/app/exercises/random-chord-practice/hooks/use-metronome.ts
@@ -22,7 +22,7 @@ export function useMetronome(
   useEffect(() => {
     setCurrentChord(generateChord())
     setNextChord(generateChord())
-  }, [])
+  }, [generateChord])
 
   useEffect(() => {
     if (isPlaying) {

--- a/app/exercises/random-chord-practice/hooks/use-metronome.ts
+++ b/app/exercises/random-chord-practice/hooks/use-metronome.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Chord } from '@/types/chord'
+import synthClickService from '../synth-click-service'
+
+export function useMetronome(
+  tempo: number,
+  isMetronomeMuted: boolean,
+  generateChord: () => Chord,
+) {
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [beat, setBeat] = useState(0)
+  const [currentChord, setCurrentChord] = useState<Chord | null>(null)
+  const [nextChord, setNextChord] = useState<Chord | null>(null)
+  const nextChordRef = useRef(nextChord)
+
+  useEffect(() => {
+    nextChordRef.current = nextChord
+  }, [nextChord])
+
+  useEffect(() => {
+    setCurrentChord(generateChord())
+    setNextChord(generateChord())
+  }, [])
+
+  useEffect(() => {
+    if (isPlaying) {
+      const intervalId = setInterval(
+        () => {
+          setBeat((beat) => (beat + 1) % 4)
+        },
+        (60 / tempo) * 1000,
+      )
+      return () => clearInterval(intervalId)
+    }
+  }, [isPlaying, tempo])
+
+  useEffect(() => {
+    if (!isPlaying) {
+      return
+    }
+    if (!isMetronomeMuted) {
+      synthClickService.play()
+    }
+    if (beat === 0) {
+      setCurrentChord(nextChordRef.current)
+      let newChord = null
+      for (let i = 0; i < 3; i++) {
+        newChord = generateChord()
+        if (
+          newChord.root !== nextChordRef.current?.root ||
+          newChord.type !== nextChordRef.current?.type
+        ) {
+          break
+        }
+      }
+      setNextChord(newChord)
+    }
+  }, [isPlaying, beat, generateChord, isMetronomeMuted])
+
+  const togglePlay = () => {
+    setIsPlaying(!isPlaying)
+  }
+
+  return {
+    isPlaying,
+    beat,
+    currentChord,
+    nextChord,
+    setIsPlaying,
+    togglePlay,
+  }
+}

--- a/app/exercises/random-chord-practice/hooks/use-practice-settings.ts
+++ b/app/exercises/random-chord-practice/hooks/use-practice-settings.ts
@@ -1,0 +1,59 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { GENERAL_MUSIC_KEYS, MusicKey } from '@/types/key'
+import { ChordType, EVERY_CHORDTYPES } from '@/types/chord'
+import { ScaleType } from '@/types/scale'
+import useLocalStorageState from '@/lib/useLocalStorageState'
+
+export function usePracticeSettings() {
+  const pathname = usePathname()
+
+  const [practiceMode, setPracticeMode] = useLocalStorageState<
+    'random' | 'diatonic'
+  >(`${pathname}:practiceMode`, 'random')
+
+  const [tempo, setTempo] = useLocalStorageState<number>(
+    `${pathname}:tempo`,
+    90,
+  )
+
+  const [isMetronomeMuted, setIsMetronomeMuted] = useLocalStorageState<boolean>(
+    `${pathname}:isMetronomeMuted`,
+    false,
+  )
+
+  const [selectedRoots, setSelectedRoots] = useLocalStorageState<MusicKey[]>(
+    `${pathname}:selectedRoots`,
+    GENERAL_MUSIC_KEYS,
+  )
+
+  const [selectedChordTypes, setSelectedChordTypes] = useLocalStorageState<
+    ChordType[]
+  >(`${pathname}:selectedChordTypes`, EVERY_CHORDTYPES)
+
+  const [selectedKey, setSelectedKey] = useLocalStorageState<MusicKey>(
+    `${pathname}:selectedKey`,
+    'C',
+  )
+
+  const [selectedScaleType, setSelectedScaleType] =
+    useLocalStorageState<ScaleType>(`${pathname}:selectedScaleType`, 'major')
+
+  return {
+    practiceMode,
+    setPracticeMode,
+    tempo,
+    setTempo,
+    isMetronomeMuted,
+    setIsMetronomeMuted,
+    selectedRoots,
+    setSelectedRoots,
+    selectedChordTypes,
+    setSelectedChordTypes,
+    selectedKey,
+    setSelectedKey,
+    selectedScaleType,
+    setSelectedScaleType,
+  }
+}

--- a/app/exercises/random-chord-practice/page.tsx
+++ b/app/exercises/random-chord-practice/page.tsx
@@ -1,225 +1,74 @@
 'use client'
-import { Button } from '@/components/ui/button'
-import { buttonVariants } from '@/components/ui/button'
-import Link from 'next/link'
-import { ChevronLeft, Circle, Pause, Play } from 'lucide-react'
-import { cn } from '@/lib/utils'
+
 import SettingsDrawer from './settings'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { GENERAL_MUSIC_KEYS, MusicKey } from '@/types/key'
-import {
-  ChordType,
-  EVERY_CHORDTYPES,
-  Chord,
-  MAJOR_DIATONIC_CHORDTYPE,
-  NATURAL_MINOR_DIATONIC_CHORDTYPE,
-} from '@/types/chord'
-import { getRandomElement } from '@/lib/utils'
-import { Skeleton } from '@/components/ui/skeleton'
-import { ChordTypeAbbreviations } from '@/types/chord'
-import useLocalStorageState from '@/lib/useLocalStorageState'
-import { usePathname } from 'next/navigation'
-import { MAJOR_SCALES, NATURAL_MINOR_SCALES, ScaleType } from '@/types/scale'
-import synthClickService from './synth-click-service'
+import { useRef, useCallback } from 'react'
+import { usePracticeSettings } from './hooks/use-practice-settings'
+import { useChordGeneration } from './hooks/use-chord-generation'
+import { useMetronome } from './hooks/use-metronome'
+import ChordDisplay from './components/chord-display'
+import MetronomeControls from './components/metronome-controls'
+import BackNavigation from './components/back-navigation'
 
 export default function RandomChordPracticePage() {
-  const [isPlaying, setIsPlaying] = useState(false)
-  const [beat, setBeat] = useState(0)
-  const wasPlayingRef = useRef(isPlaying)
+  const wasPlayingRef = useRef(false)
 
-  const pathname = usePathname()
-  const [practiceMode, setPracticeMode] = useLocalStorageState<
-    'random' | 'diatonic'
-  >(`${pathname}:practiceMode`, 'random')
-  const [tempo, setTempo] = useLocalStorageState<number>(
-    `${pathname}:tempo`,
-    90,
-  )
-  const [isMetronomeMuted, setIsMetronomeMuted] = useLocalStorageState<boolean>(
-    `${pathname}:isMetronomeMuted`,
-    false,
-  )
-  const [selectedRoots, setSelectedRoots] = useLocalStorageState<MusicKey[]>(
-    `${pathname}:selectedRoots`,
-    GENERAL_MUSIC_KEYS,
-  )
-  const [selectedChordTypes, setSelectedChordTypes] = useLocalStorageState<
-    ChordType[]
-  >(`${pathname}:selectedChordTypes`, EVERY_CHORDTYPES)
-  const [selectedKey, setSelectedKey] = useLocalStorageState<MusicKey>(
-    `${pathname}:selectedKey`,
-    'C',
-  )
-  const [selectedScaleType, setSelectedScaleType] =
-    useLocalStorageState<ScaleType>(`${pathname}:selectedScaleType`, 'major')
+  const {
+    practiceMode,
+    setPracticeMode,
+    tempo,
+    setTempo,
+    isMetronomeMuted,
+    setIsMetronomeMuted,
+    selectedRoots,
+    setSelectedRoots,
+    selectedChordTypes,
+    setSelectedChordTypes,
+    selectedKey,
+    setSelectedKey,
+    selectedScaleType,
+    setSelectedScaleType,
+  } = usePracticeSettings()
 
-  const [currentChord, setCurrentChord] = useState<Chord | null>(null)
-  const [nextChord, setNextChord] = useState<Chord | null>(null)
-  const nextChordRef = useRef(nextChord)
-
-  const getRandomChord = useCallback(
-    () => ({
-      root: getRandomElement(selectedRoots),
-      type: getRandomElement(selectedChordTypes),
-    }),
-    [selectedRoots, selectedChordTypes],
+  const { generateChord } = useChordGeneration(
+    practiceMode,
+    selectedRoots,
+    selectedChordTypes,
+    selectedKey,
+    selectedScaleType,
   )
 
-  const getRandomDiatonicChord = useCallback(() => {
-    if (selectedScaleType === 'major') {
-      const scale = MAJOR_SCALES.find((s) => s.key === selectedKey)
-      const chordTypes = MAJOR_DIATONIC_CHORDTYPE
-      if (!scale) {
-        throw new Error('Scale not found')
-      }
-      if (scale.notes.length != chordTypes.length) {
-        throw new Error('Scale and chord types do not match')
-      }
-      const random_index = Math.floor(Math.random() * scale.notes.length)
-      return {
-        root: scale.notes[random_index],
-        type: chordTypes[random_index],
-      }
-    } else if (selectedScaleType === 'natural minor') {
-      const scale = NATURAL_MINOR_SCALES.find((s) => s.key === selectedKey)
-      const chordTypes = NATURAL_MINOR_DIATONIC_CHORDTYPE
-      if (!scale) {
-        throw new Error('Scale not found')
-      }
-      if (scale.notes.length != chordTypes.length) {
-        throw new Error('Scale and chord types do not match')
-      }
-      const random_index = Math.floor(Math.random() * scale.notes.length)
-      return {
-        root: scale.notes[random_index],
-        type: chordTypes[random_index],
-      }
-    } else {
-      throw new Error('Invalid scale type')
-    }
-  }, [selectedKey, selectedScaleType])
+  const { isPlaying, beat, currentChord, nextChord, setIsPlaying, togglePlay } =
+    useMetronome(tempo, isMetronomeMuted, generateChord)
 
-  const generateChord = useCallback(() => {
-    if (practiceMode === 'random') {
-      return getRandomChord()
-    } else if (practiceMode === 'diatonic') {
-      return getRandomDiatonicChord()
-    } else {
-      throw new Error('Invalid practice mode')
-    }
-  }, [practiceMode, getRandomChord, getRandomDiatonicChord])
-
-  useEffect(() => {
-    nextChordRef.current = nextChord
-  }, [nextChord])
-
-  useEffect(() => {
-    setCurrentChord(generateChord())
-    setNextChord(generateChord())
-  }, [])
-
-  useEffect(() => {
-    if (isPlaying) {
-      const intervalId = setInterval(
-        () => {
-          setBeat((beat) => (beat + 1) % 4)
-        },
-        (60 / tempo) * 1000,
-      )
-      return () => clearInterval(intervalId)
-    }
-  }, [isPlaying, tempo, generateChord])
-
-  useEffect(() => {
-    if (!isPlaying) {
-      return
-    }
-    if (!isMetronomeMuted) {
-      synthClickService.play()
-    }
-    if (beat === 0) {
-      setCurrentChord(nextChordRef.current)
-      let newChord = null
-      // Try to generate a new chord that is different from the current one
-      for (let i = 0; i < 3; i++) {
-        newChord = generateChord()
-        if (
-          newChord.root !== nextChordRef.current?.root ||
-          newChord.type !== nextChordRef.current?.type
-        ) {
-          break
-        }
+  const handleSettingsOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        wasPlayingRef.current = isPlaying
+        setIsPlaying(false)
+      } else {
+        setIsPlaying(wasPlayingRef.current)
       }
-      setNextChord(newChord)
-    }
-  }, [isPlaying, beat, generateChord, isMetronomeMuted])
+    },
+    [isPlaying, setIsPlaying],
+  )
 
   return (
     <div className="relative flex flex-col sm:py-6">
-      <div>
-        <Link
-          className={cn(buttonVariants({ variant: 'ghost' }), 'pl-2 pr-4')}
-          href="/exercises"
-        >
-          <ChevronLeft className="h-6 w-6" />
-          Back to Exercises
-        </Link>
-      </div>
+      <BackNavigation />
       <div className="px-4 py-2">
         <div className="text-2xl font-bold">Random chord practice</div>
         <div className="flex flex-col items-center py-12">
-          <div
-            className="flex flex-col items-center"
-            onClick={() => setIsPlaying(!isPlaying)}
-          >
-            {currentChord ? (
-              <div className="mb-4 text-7xl font-semibold tracking-tight sm:mb-8 sm:text-9xl">
-                {currentChord.root + ChordTypeAbbreviations[currentChord.type]}
-              </div>
-            ) : (
-              <Skeleton className="mb-4 h-24 w-48 sm:mb-8" />
-            )}
-            <div className="mb-4 text-2xl sm:text-3xl">Up Next...</div>
-            {nextChord ? (
-              <div className="text-6xl font-semibold tracking-tight sm:mb-8 sm:text-8xl">
-                {nextChord.root + ChordTypeAbbreviations[nextChord.type]}
-              </div>
-            ) : (
-              <Skeleton className="h-16 w-32" />
-            )}
-          </div>
-          <div className="flex items-center justify-between gap-8 py-12 sm:mb-12 sm:gap-16">
-            {[0, 1, 2, 3].map((i) => (
-              <Circle
-                key={i}
-                className={cn(
-                  'h-12 w-12 fill-secondary-foreground sm:h-16 sm:w-16',
-                  {
-                    'fill-primary-foreground': i === beat,
-                  },
-                )}
-              />
-            ))}
-          </div>
-          <div className="flex items-center gap-4">
-            <Button
-              className="h-12 w-36"
-              onClick={() => {
-                setIsPlaying(!isPlaying)
-              }}
-            >
-              {isPlaying ? (
-                <div className="flex items-center gap-1">
-                  <Pause className="h-6 w-6" />
-                  <div className="text-lg">Pause</div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-1">
-                  <Play className="h-6 w-6" />
-                  <div className="text-lg">Play</div>
-                </div>
-              )}
-            </Button>
+          <ChordDisplay
+            currentChord={currentChord}
+            nextChord={nextChord}
+            onTogglePlay={togglePlay}
+          />
+          <MetronomeControls
+            isPlaying={isPlaying}
+            beat={beat}
+            onTogglePlay={togglePlay}
+          />
+          <div className="mt-4">
             <SettingsDrawer
               practiceMode={practiceMode}
               setPracticeMode={setPracticeMode}
@@ -235,14 +84,7 @@ export default function RandomChordPracticePage() {
               setSelectedKey={setSelectedKey}
               selectedScaleType={selectedScaleType}
               setSelectedScaleType={setSelectedScaleType}
-              onOpenChange={(open) => {
-                if (open) {
-                  wasPlayingRef.current = isPlaying
-                  setIsPlaying(false)
-                } else {
-                  setIsPlaying(wasPlayingRef.current)
-                }
-              }}
+              onOpenChange={handleSettingsOpenChange}
             />
           </div>
         </div>

--- a/app/exercises/random-chord-practice/settings.tsx
+++ b/app/exercises/random-chord-practice/settings.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Switch } from '@/components/ui/switch'
 import {
   Drawer,
   DrawerClose,
@@ -9,231 +8,15 @@ import {
   DrawerTrigger,
 } from '@/components/ui/drawer'
 import { Button } from '@/components/ui/button'
-import { Slider } from '@/components/ui/slider'
-import { Check, Settings } from 'lucide-react'
-import { Separator } from '@/components/ui/separator'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Settings } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import RandomModeSettings from './components/random-mode-settings'
+import DiatonicModeSettings from './components/diatonic-mode-settings'
 
-import { GENERAL_MUSIC_KEYS, MusicKey } from '@/types/key'
-import { ChordType, SEVENTH_CHORDTYPES, TRIAD_CHORDTYPES } from '@/types/chord'
+import { MusicKey } from '@/types/key'
+import { ChordType } from '@/types/chord'
 import { ScaleType } from '@/types/scale'
-
-function TempoSlider({
-  tempo,
-  setTempo,
-}: {
-  tempo: number
-  setTempo: (tempo: number) => void
-}) {
-  return (
-    <div>
-      <div className="mb-3 flex items-center justify-between">
-        <div className="font-semibold">Tempo</div>
-        <div>{tempo} BPM</div>
-      </div>
-      <Slider
-        value={[tempo]}
-        onValueChange={([value]) => {
-          setTempo(value)
-        }}
-        max={200}
-        min={30}
-        step={1}
-      />
-    </div>
-  )
-}
-
-function MetronomeSwitch({
-  isMetronomeMuted,
-  setIsMetronomeMuted,
-}: {
-  isMetronomeMuted: boolean
-  setIsMetronomeMuted: (muted: boolean) => void
-}) {
-  return (
-    <div className="flex items-center justify-between">
-      <div className="font-semibold">Metronome Sound</div>
-      <Switch
-        checked={!isMetronomeMuted}
-        onCheckedChange={(check) => {
-          setIsMetronomeMuted(!check)
-        }}
-      />
-    </div>
-  )
-}
-
-function RootSelect({
-  selectedRoots,
-  setSelectedRoots,
-}: {
-  selectedRoots: MusicKey[]
-  setSelectedRoots: (roots: MusicKey[]) => void
-}) {
-  return (
-    <div>
-      <div className="mb-3 font-semibold">Roots</div>
-      <ToggleGroup
-        type="multiple"
-        variant="outline"
-        className="grid grid-cols-4 sm:grid-cols-6"
-        value={selectedRoots}
-        onValueChange={(value) => {
-          if (value.length > 0) {
-            setSelectedRoots(value as MusicKey[])
-          }
-        }}
-      >
-        {GENERAL_MUSIC_KEYS.map((note) => (
-          <ToggleGroupItem
-            key={note}
-            value={note}
-            className="text-sm font-semibold"
-          >
-            {note}
-          </ToggleGroupItem>
-        ))}
-      </ToggleGroup>
-    </div>
-  )
-}
-
-function ChordTypeSelect({
-  selectedChordTypes,
-  setSelectedChordTypes,
-}: {
-  selectedChordTypes: ChordType[]
-  setSelectedChordTypes: (chordTypes: ChordType[]) => void
-}) {
-  return (
-    <div>
-      <div className="mb-3 font-semibold">Chords</div>
-      <div className="grid grid-cols-2 items-start gap-4">
-        <ToggleGroup
-          type="multiple"
-          variant="outline"
-          className="flex flex-col"
-          value={selectedChordTypes.filter((chord) =>
-            TRIAD_CHORDTYPES.includes(chord),
-          )}
-          onValueChange={(value) => {
-            setSelectedChordTypes(
-              (value as ChordType[]).concat(
-                selectedChordTypes.filter(
-                  (chord) => !TRIAD_CHORDTYPES.includes(chord),
-                ),
-              ),
-            )
-          }}
-        >
-          {TRIAD_CHORDTYPES.map((chord) => (
-            <ToggleGroupItem
-              key={chord}
-              value={chord}
-              className="relative w-full font-semibold"
-            >
-              <div className="flex">{chord}</div>
-              {selectedChordTypes.includes(chord) && (
-                <Check className="absolute right-4 h-5 w-5" />
-              )}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
-        <ToggleGroup
-          type="multiple"
-          variant="outline"
-          className="flex flex-col"
-          value={selectedChordTypes.filter((chord) =>
-            SEVENTH_CHORDTYPES.includes(chord),
-          )}
-          onValueChange={(value) => {
-            setSelectedChordTypes(
-              (value as ChordType[]).concat(
-                selectedChordTypes.filter(
-                  (chord) => !SEVENTH_CHORDTYPES.includes(chord),
-                ),
-              ),
-            )
-          }}
-        >
-          {SEVENTH_CHORDTYPES.map((chord) => (
-            <ToggleGroupItem
-              key={chord}
-              value={chord}
-              className="relative w-full font-semibold"
-            >
-              <div className="flex">{chord}</div>
-              {selectedChordTypes.includes(chord) && (
-                <Check className="absolute right-4 h-5 w-5" />
-              )}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
-      </div>
-    </div>
-  )
-}
-
-function KeySelect({
-  selectedKey,
-  setSelectedKey,
-}: {
-  selectedKey: MusicKey
-  setSelectedKey: (key: MusicKey) => void
-}) {
-  return (
-    <div>
-      <div className="mb-3 font-semibold">Key</div>
-      <ToggleGroup
-        type="single"
-        variant="outline"
-        className="grid grid-cols-4 sm:grid-cols-6"
-        value={selectedKey}
-        onValueChange={(value) => {
-          setSelectedKey(value as MusicKey)
-        }}
-      >
-        {GENERAL_MUSIC_KEYS.map((note) => (
-          <ToggleGroupItem
-            key={note}
-            value={note}
-            className="text-sm font-semibold"
-          >
-            {note}
-          </ToggleGroupItem>
-        ))}
-      </ToggleGroup>
-    </div>
-  )
-}
-
-function ScaleTypeSelect({
-  scaleType,
-  setScaleType,
-}: {
-  scaleType: ScaleType
-  setScaleType: (scaleType: ScaleType) => void
-}) {
-  return (
-    <div>
-      <div className="mb-3 font-semibold">Scale type</div>
-      <Tabs
-        value={scaleType}
-        onValueChange={(value) => {
-          setScaleType(value as ScaleType)
-        }}
-      >
-        <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="major">Major</TabsTrigger>
-          <TabsTrigger value="natural minor">Minor</TabsTrigger>
-        </TabsList>
-      </Tabs>
-    </div>
-  )
-}
 
 export default function SettingsDrawer({
   practiceMode,
@@ -297,24 +80,16 @@ export default function SettingsDrawer({
                 </TabsList>
               </div>
               <TabsContent value="random">
-                <Separator orientation="horizontal" className="mb-4" />
-                <TempoSlider tempo={tempo} setTempo={setTempo} />
-                <Separator orientation="horizontal" className="my-4" />
-                <MetronomeSwitch
+                <RandomModeSettings
+                  tempo={tempo}
+                  setTempo={setTempo}
                   isMetronomeMuted={isMetronomeMuted}
                   setIsMetronomeMuted={setIsMetronomeMuted}
-                />
-                <Separator orientation="horizontal" className="my-4" />
-                <RootSelect
                   selectedRoots={selectedRoots}
                   setSelectedRoots={setSelectedRoots}
-                />
-                <Separator orientation="horizontal" className="my-4" />
-                <ChordTypeSelect
                   selectedChordTypes={selectedChordTypes}
                   setSelectedChordTypes={setSelectedChordTypes}
                 />
-                <Separator orientation="horizontal" className="mt-4" />
                 <DrawerFooter>
                   <DrawerClose>
                     <Button variant="outline">Close</Button>
@@ -322,19 +97,14 @@ export default function SettingsDrawer({
                 </DrawerFooter>
               </TabsContent>
               <TabsContent value="diatonic">
-                <Separator orientation="horizontal" className="mb-4" />
-                <TempoSlider tempo={tempo} setTempo={setTempo} />
-                <Separator orientation="horizontal" className="my-4" />
-                <KeySelect
+                <DiatonicModeSettings
+                  tempo={tempo}
+                  setTempo={setTempo}
                   selectedKey={selectedKey}
                   setSelectedKey={setSelectedKey}
+                  selectedScaleType={selectedScaleType}
+                  setSelectedScaleType={setSelectedScaleType}
                 />
-                <Separator orientation="horizontal" className="my-4" />
-                <ScaleTypeSelect
-                  scaleType={selectedScaleType}
-                  setScaleType={setSelectedScaleType}
-                />
-                <Separator orientation="horizontal" className="mt-4" />
                 <DrawerFooter>
                   <DrawerClose>
                     <Button variant="outline">Close</Button>

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -12,21 +12,7 @@ import {
   NavigationMenuList,
   navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu'
-
-export const menuItems = [
-  {
-    title: 'Exercises',
-    href: '/exercises',
-  },
-  {
-    title: 'About',
-    href: '/about',
-  },
-  {
-    title: 'Contact',
-    href: '/contact',
-  },
-]
+import { menuItems } from '@/config/navigation'
 
 export default function MainNav() {
   const pathname = usePathname()

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Menu, Music } from 'lucide-react'
-import { menuItems } from './main-nav'
+import { menuItems } from '@/config/navigation'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import Link from 'next/link'
 import { useState } from 'react'

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -1,0 +1,14 @@
+export const menuItems = [
+  {
+    title: 'Exercises',
+    href: '/exercises',
+  },
+  {
+    title: 'About',
+    href: '/about',
+  },
+  {
+    title: 'Contact',
+    href: '/contact',
+  },
+]


### PR DESCRIPTION
- Split large components into focused, reusable pieces:
  * Extract ChordDisplay component (40 lines)
  * Extract MetronomeControls component (51 lines)
  * Extract BackNavigation component (23 lines)
  * Extract RandomModeSettings component (156 lines)
  * Extract DiatonicModeSettings component (88 lines)

- Create custom hooks for business logic separation:
  * useChordGeneration hook - chord generation logic
  * useMetronome hook - metronome state and timing
  * usePracticeSettings hook - localStorage state management

- Eliminate code duplication:
  * Create shared navigation configuration
  * Update navigation components to use shared config

- Add performance optimizations:
  * React.memo for component memoization
  * useCallback for event handlers
  * useMemo for expensive calculations
  * Optimized useEffect dependencies

- Reduce component complexity:
  * RandomChordPractice: 252→94 lines
  * Settings: 350→120 lines

All functionality preserved with improved code organization.